### PR TITLE
Fix spacing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Alternativ: Supabase (falls gehostet & leicht verwaltbar sein soll)
 #   Microservice	        Aufgabe	                                        Sprache
 
     Gateway/API 	        Zentrale Schnittstelle,                         Auth, Routing	Node.js
-    PDF-Service	            Parsing,Umbenennung, Text extrahieren	        Python
+    PDF-Service	            Parsing, Umbenennung, Text extrahieren	        Python
     KI-Service	            Anbindung an LLM, Prompts, Klassifikation	    Python
     Datenbank-Service	    Verwaltung der Metadaten, Suche	                Node.js
     LLM-Service	            Lokaler LLM, Anfrageverarbeitung	            Python


### PR DESCRIPTION
## Summary
- add missing space after comma in `PDF-Service` description

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683ff4d5fe448330aac488a0ad04fa93